### PR TITLE
leapp-inspector: add README and bash-completion script

### DIFF
--- a/scripts/leappinspector/README.md
+++ b/scripts/leappinspector/README.md
@@ -1,0 +1,50 @@
+# Leapp-inspector
+
+The leapp-inspector script can be used as library for python scripts or as a tool
+when it is executed directy.
+
+The main purpose of Leapp-inspector is to help with investigation / debugging
+of the Leapp execution based on data in the leapp db. E.g. what actors have
+been executed, what meesages have been produced, what happened during
+the execution of leapp, ...
+
+## Requirements
+The script is Python2 & Python3 compatible. By default, when execute the tool,
+Python3 is required. In case you want to use the tool with Python2, invoke it
+directly with python2 (`python2 ./leapp-inspector`) or change the shebang.
+
+Only required dependcies to use the script are Python2 or Python3 standard
+libraries. So having installed Python, nothing else is needed.
+
+## How to use the tool
+
+The most simple use of the tool is execute it in the direcotry with the leapp
+db file (usually `leapp.db`) and use a subcommand you wish to get some data.
+E.g.
+```
+ # to print all messages produced by actors
+ leapp-inspector messages
+
+ # to list all executed actors
+ leapp-inspector actors --list-executed
+
+ # print help to see more..
+ leapp-inspector help
+```
+
+If the leapp db file is located in different than current working directory
+or has a different name, use th `--db` option (prior a subcommand) to specify
+location of the leapp db file.
+
+## bash-completion
+For convenient use, the bash-completion file is located under the bash-completion
+directory. To install it, just copy it under your bash-completion. If you want
+to specify bash-completion on the user level, do somethin like that:
+1. create ~/.bash-completion.d directory
+1. copy the script inside
+1. create user's ~/.bash\_completion configuration script:
+```
+for bcfile in $(find ~/.bash_completion.d/ -type f -exec grep -Iq . {} \; -print) ; do
+  . $bcfile
+done
+```

--- a/scripts/leappinspector/README.md
+++ b/scripts/leappinspector/README.md
@@ -8,6 +8,12 @@ of the Leapp execution based on data in the leapp db. E.g. what actors have
 been executed, what meesages have been produced, what happened during
 the execution of leapp, ...
 
+## DISCLAIMER
+
+The code is not stabilized yet! It's under heavy development!
+You should expect that output format, CLI, and classes/functions in the script
+can be significantly changed without notification and without sorry.
+
 ## Requirements
 The script is Python2 & Python3 compatible. By default, when execute the tool,
 Python3 is required. In case you want to use the tool with Python2, invoke it

--- a/scripts/leappinspector/completion/leapp-inspector.bash
+++ b/scripts/leappinspector/completion/leapp-inspector.bash
@@ -1,0 +1,212 @@
+_get_subcommands() {
+    # if the leapp-inspector command is not available, return predefined
+    # set of subcommands
+    command -v leapp-inspector >/dev/null || {
+        echo help actors messages executions interactive inspecion
+        return
+    }
+    leapp-inspector help \
+        | grep -A1 -m1 "^Subcommands:" \
+        | tail -n1 \
+        | tr "{}," "   "
+}
+
+_get_dbfile() {
+    # print existing leapp db file or nothing + return
+    # return 0 if discovered, otherwise 1
+    local use_next=0
+    for word in "${COMP_WORDS[@]}"; do
+       if [[ "$use_next" == "1" ]]; then
+           [[ -e "$word" ]] || return 1
+           echo "$word"
+           return 0
+       fi
+       if [[ "$word" == "--db" ]]; then
+           use_next=1
+       fi
+    done
+
+    [[ -e "leapp.db" ]] || return 1
+    echo "leapp.db"
+    return 0
+}
+
+_get_context() {
+    # if an existing context is set in cmdline already, print it
+    # return 0 if context set, otherwise 1
+    local use_next=0
+    for word in "${COMP_WORDS[@]}"; do
+       if [[ "$use_next" == "1" ]]; then
+           [[ -e "$word" ]] || return 1
+           echo "$word"
+           return 0
+       fi
+       if [[ "$word" == "--context" ]]; then
+           use_next=1
+       fi
+    done
+
+    return 1
+}
+
+in_array() {
+    local i
+    for i in $2; do
+        [[ $i = $1 ]] && return 0
+    done
+    return 1
+}
+
+_gen_leapp_inspector_cmd() {
+    # gen leapp-inspector command if the leapp db file exists
+    dbfile="$(_get_dbfile)"
+    [[ -z "$dbfile" ]] && return 1
+    context="$(_get_context)"
+    [[ -z "$context" ]] || context="--context $context"
+    echo "leapp-inspector --db $dbfile $context"
+    return 0
+}
+
+_handle_subcmd_actors() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local opts="--help --list-executed --list--producers --actor --terminal-like --log-level"
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    case "$prev" in
+        --actor)
+            cmd="$(_gen_leapp_inspector_cmd)"
+            [[ -z "$cmd" ]] && return 0
+            actors=$($cmd actors --list-executed)
+            COMPREPLY=( $(compgen -W "$actors" -- "$cur") )
+            ;;
+        --log-level)
+            COMPREPLY=( $(compgen -W "ERROR WARNING INFO DEBUG" -- "$cur") )
+            ;;
+        *)
+            COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+            ;;
+    esac
+}
+
+_handle_subcmd_messages() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local opts="--help --list --actor --type --phase --recursive-expand"
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    case "$prev" in
+        --actor)
+            cmd="$(_gen_leapp_inspector_cmd)"
+            [[ -z "$cmd" ]] && return 1
+            actors=$($cmd actors --list-executed)
+            COMPREPLY=( $(compgen -W "$actors" -- "$cur") )
+            ;;
+        --type)
+            cmd="$(_gen_leapp_inspector_cmd)"
+            [[ -z "$cmd" ]] && return 1
+            msg_types=$($cmd messages --list)
+            COMPREPLY=( $(compgen -W "$msg_types" -- "$cur") )
+            ;;
+        --phase)
+            cmd="$(_gen_leapp_inspector_cmd)"
+            [[ -z "$cmd" ]] && return 1
+            phases=$($cmd messages | grep "^Phase" | cut -f 2 -d ":" | sort | uniq)
+            COMPREPLY=( $(compgen -W "$phases" -- "$cur") )
+            ;;
+        *)
+            COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+            ;;
+    esac
+}
+
+_handle_subcmd_inspection() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local opts="--help --paranoid"
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    case "$prev" in
+        *)
+            COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+            ;;
+    esac
+}
+
+_leapp_inspector_complete () {
+    COMPREPLY=()
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local gen_opts="--help --context --db"
+    local subcmds="$(_get_subcommands)"
+    local subcmd=
+    local word=
+
+    for word in "${COMP_WORDS[@]}"; do
+       if in_array "$word" "$subcmds"; then
+           subcmd="$word"
+           break
+       fi
+    done
+
+    if  [[ -z "$subcmd" ]]; then
+        if [[ "$cur" == -* ]]; then
+           # suggest generic options
+           COMPREPLY=( $(compgen -W "$gen_opts" -- "$cur") )
+           return 0
+        fi
+
+        case "$prev" in
+            --context)
+                dbfile="$(_get_dbfile)"
+                [[ -z "$dbfile" ]] && return 1
+                words=$(leapp-inspector --db "$dbfile" executions | grep -o "^[0-9a-f][^ ]*")
+                COMPREPLY=( $(compgen -W "$words" -- "$cur") )
+                ;;
+            --db)
+                _filedir
+                ;;
+            *)
+                COMPREPLY=( $(compgen -W "$subcmds" -- "$cur") )
+                ;;
+        esac
+    else
+        if [[ "$cur" == "$subcmd" ]]; then
+           # subcmd is discovered but maybe unfinished, case like:
+           #    'hello' is written but 'hello' and 'hello-kitty' subcmds exist
+           # or 'hello' is written and cursor is in the end of the 'hello'
+           # in such case, to be able to move on when <TAB> is pressed, add
+           # even 'hello ' to possible options...
+           COMPREPLY=( $(compgen -W "$gen_opts '$subcmd '" -- "$cur") )
+           return 0
+        fi
+
+        # and now handle options for specific subcommands..
+        case "$subcmd" in
+            actors)
+                _handle_subcmd_actors
+                ;;
+            messages)
+                _handle_subcmd_messages
+                ;;
+            inspection)
+                _handle_subcmd_inspection
+                ;;
+            *)
+                COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+                ;;
+        esac
+    fi
+
+    return 0
+}
+complete -F _leapp_inspector_complete leapp-inspector

--- a/scripts/leappinspector/leapp-inspector
+++ b/scripts/leappinspector/leapp-inspector
@@ -14,6 +14,12 @@ except ImportError:
 from pprint import pprint as pp
 
 """
+============= DISCLAIMER ==================
+The code is not stabilized yet! Read: it's under heavy development!
+You should expect that output format, CLI, and classes/functions in the script
+can be significantly changed without notification.
+===========================================
+
 The current code is written as library and tool in one file, as it's expected
 it will be copied oftenly; so for now, just one file to make copying simple.
 Installation is not needed. Just copy the script wherever you want and use it.


### PR DESCRIPTION
The README.md file roughly document the purpose and usage of the
leapp-inspector. As well, contains instructions how to install
the bash-completion script under a user.

The bash completion script covers all current subcommands and options.