### PR TITLE
Change model name key

### DIFF
--- a/scripts/actors-models-graph.py
+++ b/scripts/actors-models-graph.py
@@ -125,8 +125,8 @@ if __name__ == '__main__':
     # Actor.tags - cluster
     # Actor.dialogs - changes shape of the vertex if actor has dialogs
     actors = [Actor(name=actor.class_name,
-                    consumes=tuple(c.serialize()['name'] for c in actor.consumes),
-                    produces=tuple(p.serialize()['name'] for p in actor.produces),
+                    consumes=tuple(c.serialize()['class_name'] for c in actor.consumes),
+                    produces=tuple(p.serialize()['class_name'] for p in actor.produces),
                     tags=[elem for elem in tuple(t.serialize()['name'] for t in actor.tags)
                           if elem != 'IPUWorkflowTag'],
                     dialogs=[d.scope for d in getattr(actor, "dialogs", [])]


### PR DESCRIPTION
The key for model name in its serialized form has changed. This commit ensures the graph script uses the correct key.

Related: oamg/leapp@0e4bf2b574c0bf450e21fb4785ba1cae5c695d6a