### PR TITLE
leapp-inspector: fix detection of inhibitor for "inspection" cmd

### DIFF
--- a/scripts/leappinspector/leapp-inspector
+++ b/scripts/leappinspector/leapp-inspector
@@ -967,7 +967,7 @@ class InteractiveCLI(SubCommandBaseClass):
         )
         print(
             "Hint:\n"
-            "    Execute self.LeappDatabase or self.LeapDataPrint to get\n"
+            "    Execute self.LeappDatabase or self.LeapDataPrinter to get\n"
             "    already initialized objects."
         )
         self.LeappDataPrinter._print_tail()
@@ -1039,8 +1039,8 @@ class InspectionCLI(SubCommandBaseClass):
         return False
 
     def _inhibitor_exist(self):
-        for msg in self.LeappDatabase.get_messages():
-            data = json.loads(msg["message_data"])
+        for msg in self.LeappDatabase.get_messages(msg_type="Report"):
+            data = json.loads(json.loads(msg["message_data"])["report"])
             # FIXME: flags are going to be removed and replace
             # by groups
             # FIXME: when the failure is used?


### PR DESCRIPTION
Previously the "inspection" cmd reported always no inhibitor detected.
This has been caused by invorrect processing of Report msgs which
have a little bit different structure. That's fixed now.