### PR TITLE
Handle broken pipe issue

### DIFF
--- a/scripts/leappinspector/leapp-inspector
+++ b/scripts/leappinspector/leapp-inspector
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
 
 import argparse
+import errno
 import json
 import os
 import re
+import socket
 import sqlite3
 import sys
 try:
@@ -1075,7 +1077,13 @@ def set_default_subcommands(cli):
     cli.add_subcommand(InspectionCLI)
 
 if __name__ == '__main__':
-    cli = LeappInspectorCLI()
-    set_default_subcommands(cli)
-    cli.parse()
-    cli.process()
+    try:
+        cli = LeappInspectorCLI()
+        set_default_subcommands(cli)
+        cli.parse()
+        cli.process()
+    except socket.error as e:
+        if e.errno != errno.EPIPE:
+            raise
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())


### PR DESCRIPTION
One of common use-cases is piping the leapp inspector output to another utilis - such as less:
  $ leapp-inspector messages | less

It's annoying to see the broken
pipe traceback after closing the application. Fix that for Py2 & Py3 to not see this error anymore.

### Note
Currently it works just under Py3. Py2 is still broken.