### PR TITLE
Fix print of "Executed shell commands" for Py3

### DIFF
--- a/scripts/leappinspector/leapp-inspector
+++ b/scripts/leappinspector/leapp-inspector
@@ -514,7 +514,10 @@ class LeappDataPrinter(LeappDatabase):
             print("    ----")
 
         print("Executed shell commands:")
-        cmd_regexp = re.compile(r"External command has started: (.+\])\",")
+        # NOTE(pstodulk): That regular is terrible, I know
+        # be aware that order of json fields in the log is different on
+        # py2 and py3
+        cmd_regexp = re.compile(r"External command has started: (.+\])\"[,}]")
         cmds = []
         for log in self.get_logs(actor=actor_name):
             match = cmd_regexp.search(log["data"])


### PR DESCRIPTION
Running `leapp-inspector actors ...` command, one of outputs is the list of executed shell commands. However, the stored log has different order of fields on Py2 & Py3 (so in time of leapp execution, no in time of running leapp-inspector). Due to this, the list of executed shell commands have been empty for leapp executed via Py3 as the content is obtained using a regexp. Update the regexp to ignore order of fields.

Note: I know this is not ideal implementation at all. Not sure whether somewhere in the code more dragons are hidden. So far, it works right now.

Fixes: #16 