### PR TITLE
Add completions for zsh

### DIFF
--- a/scripts/leappinspector/README.md
+++ b/scripts/leappinspector/README.md
@@ -37,21 +37,25 @@ where Python2 is still present as default, change the shebang (the first line
 of the script) from python3 to python2 to make the tool working for you. The tooling
 is now Python2 & Python3 compatible.
 
-### Install the bash-completion for leapp-inspector
+### Shell completion
+Instructions below for your prefered shell.
+
+#### bash
+Install the bash-completion for leapp-inspector
 For convenient use, the bash-completion file is located under the bash-completion
 directory. To install it, just copy it under your bash-completion. If you want
 to specify bash-completion on the user level, do somethin like that:
 1. create ~/.bash\_completion.d directory
 1. copy the script inside
 1. create user's ~/.bash\_completion configuration script:
-```
+```bash
 for bcfile in $(find ~/.bash_completion.d/ -type f -exec grep -Iq . {} \; -print) ; do
   . $bcfile
 done
 ```
 
 or just copy&paste this script:
-```
+```bash
 leapp_inspector_bcomp_url=https://raw.githubusercontent.com/oamg/snippets/master/scripts/leappinspector/completion/leapp-inspector.bash
 mkdir ~/.bash_completion.d
 curl -kL $leapp_inspector_bcomp_url > ~/.bash_completion.d/leapp-inspector.bash
@@ -64,8 +68,38 @@ EOF
 
 If you do everything correct, the bash-completion will be loaded the next time
 you login or when you manually execute:
-```
+```bash
 source ~/.bash_completion
+```
+
+#### zsh
+> [!IMPORTANT]
+> You need to have the completion module loaded in for the completions to work.
+> This is outside of the scope of these instructions, but `autoload -Uz
+> compinit; compinit` should do it.
+
+> [!IMPORTANT]
+> These instructions were tested on a zsh install without `oh-my-zsh`.
+> In `oh-my-zsh`, there is the `~/.oh-my-zsh/completions/` directory for
+> completions, however we recommend to look in the `oh-my-zsh` documentation
+> for instructions.
+
+There isn't a standard directory for user-defined completions for zsh. Instead
+zsh looks in directories in `fpath` (`$FPATH`). This guide is therefore more of
+an example, tailor it to your config:
+```sh
+# create a directory for completions
+if [ -z "$ZDOTDIR"]; then
+    comp_dir = "$ZDOTDIR/completion"
+else
+    # add an intermediate .zsh dir to avoid cluttering $HOME
+    comp_dir = "$HOME/.zsh/completion"
+fi
+mkdir -p "$comp_dir"
+
+# add the dir to fpath automatically
+echo "fpath+=("$comp_dir")" >> zshrc=${ZDOTDIR:-$HOME}/.zshrc
+cp completion/_leapp-inspector  "$comp_dir"
 ```
 
 ## How to use the tool
@@ -73,7 +107,7 @@ source ~/.bash_completion
 The most simple use of the tool is execute it in the direcotry with the leapp
 db file (usually `leapp.db`) and use a subcommand you wish to get some data.
 E.g.
-```
+```bash
  # to print all messages produced by actors
  leapp-inspector messages
 

--- a/scripts/leappinspector/completion/_leapp-inspector
+++ b/scripts/leappinspector/completion/_leapp-inspector
@@ -1,0 +1,138 @@
+#compdef leapp-inspector
+
+_leapp_inspector_executed_actors() {
+  command -v leapp-inspector >/dev/null || {
+    return 1
+  }
+
+  actors=(${(f)"$(${=base_cmd} actors --list-executed | tr -s '[:space:]\n' '\n')"})
+  actors=("${(@)actors##[[:space:]]##}") # trim leading whitespace
+  _describe 'actor names' actors
+}
+
+_leapp_inspector_messages_list() {
+  command -v leapp-inspector >/dev/null || {
+    return 1
+  }
+
+  types=(${(f)"$(${=base_cmd} messages --list | tr -s '[:space:]\n' '\n')"})
+  types=("${(@)types##[[:space:]]##}") # trim leading whitespace
+  _describe 'message types' types
+}
+
+_leapp_inspector_phases_list() {
+  command -v leapp-inspector >/dev/null || {
+    return 1
+  }
+
+  phases=(${(f)"$(${=base_cmd} messages | grep "^Phase" | cut -f 2 -d ":" | sort -u)"})
+  phases=("${(@)phases##[[:space:]]##}") # trim leading whitespace
+  _describe 'phases' phases
+}
+
+_leapp_inspector_subcommands() {
+  command -v leapp-inspector >/dev/null || {
+    _describe 'commands' (help actors messages executions interactive inspecion)
+      return
+    }
+
+  local -a subcmds
+  temp=$(
+    leapp-inspector help \
+      | grep -A1 -m1 "^Subcommands:" \
+      | tail -n1
+    )
+    temp=${temp#*\{} # strip leading whitespace and }
+    temp=${temp%\}*} # strip trailing } and whitespace
+    subcmds=(${(s:,:)temp}) # split on , into array
+      _describe 'command' subcmds
+    }
+
+  _leapp_inspector() {
+    local context state state_descr line
+    local -A opt_args
+
+    _arguments -C \
+      '(-h --help)'{-h,--help}'[show help message]' \
+      '--db[specify database file]:file:_files' \
+      '--context[specify context]:context:->ctx' \
+      '1:subcommand:_leapp_inspector_subcommands' \
+      '*::arg:->args' && return 0
+
+    local -a cmd_args
+    local db=${opt_args[--db]}
+
+    if [[ -n "$db" ]]; then 
+      cmd_args+=("--db $db")
+    elif [[ ! -e leapp.db && ! -e /var/lib/leapp/leapp.db ]]; then
+      # --db is not specified and the default locations don't exist, we can't complete
+      return 1
+    fi
+
+    local ctx=${opt_args[--ctx]}
+    [[ -n "$ctx" ]] && cmd_args+=("--context $ctx")
+
+    local -a base_cmd
+    base_cmd=("leapp-inspector ${cmd_args[@]}")
+
+    case $state in
+      ctx)
+        # do this here since we have easy access to the dbfile
+        local -a ctx
+        ctxs=(${(f)"$("${=base_cmd}" executions 2>/dev/null | grep -o "^[0-9a-f][^ ]*")"})
+        _describe -t contexts 'available contexts' ctxs
+        ;;
+      args)
+        # NOTE: _arguments allows specifying a callback function in place
+        # of the e.g. '->actor', however the callbacks can get executed
+        # directly, i.e. without any of the variables in this
+        # (_leapp_inspector) function.
+        # The base_cmd variable is however essential for the helpers to
+        # properly (with the specified DB and context) execute
+        # leapp-inspector. For this reason callbacks are not used and we
+        # call the helpers ourselves based on $state. This is slightly
+        # slower, but I havent found a better way.
+        case $words[1] in
+          actors)
+            # NOTE:
+            # only one of the option inside parentheses can be specified
+            _arguments -C \
+              '(-h --help)'{-h,--help}'[show help message and exit]' \
+              '(--list-executed --list-producers --actor)--list-executed[list all executed actors]' \
+              '(--list-executed --list-producers --actor)--list-producers[list all actors that produced any messages]' \
+              '(--list-executed --list-producers --actor)--actor[print data related to specified actor]:actor name:->actor' \
+              '--log-level[print logs of given level and lower]:level:(ERROR WARNING INFO DEBUG)' \
+              '--terminal-like[print logs like in terminal with indentation]'
+            case $state in
+              actor) _leapp_inspector_executed_actors ;;
+            esac
+            ;;
+          messages)
+            _arguments -C \
+              '(-h --help)'{-h,--help}'[show help message and exit]' \
+              '--list[list types of all produced messages]' \
+              '--actor[print only messages produced by the actor]:actor:->actor' \
+              '--type[print only messages of the given type]:type:->type' \
+              '--phase[print only messages from the given phase]:phase:->phase' \
+              '--recursive-expand[expand all JSON data recursively]'
+            case $state in
+              actor) _leapp_inspector_executed_actors ;;
+              type) _leapp_inspector_messages_list ;;
+              phase) _leapp_inspector_phases_list ;;
+            esac
+            ;;
+          inspection)
+            _arguments \
+              '(-h --help)'{-h,--help}'[show help message and exit]' \
+              "--paranoid[set inspection to the paranoid mode]"
+            ;;
+          *)
+            _arguments \
+              '(-h --help)'{-h,--help}'[show help message and exit]'
+            ;;
+        esac
+        ;;
+    esac
+  }
+
+_leapp_inspector "$@"


### PR DESCRIPTION
This patch adds completion for `zsh`. I wrote this for me, however others might appreciate this as well as the completion system and "UI" in `zsh` is more flexible (e.g. option descriptions right in the completion menu, see examples below) and also `zsh` is the default shell on MacOS.

This is written from scratch for the most part, as `bash` completion system is quite different, however the completion should behave the same. 

The completion system of `zsh` is quite complex, however the introduced script should be understandable enough to be extended in the future without diving deep into the details. I commented some of the possible problems in the script.
The script must be called `_<command name>`, **without** extension.

It's not possible to create a clean installation script because user-defined completion doesn't have standardized locations for completion, so the instructions are more like an example.
If leapp-inspector ever becomes a package it's possible to install it into `/usr/share/zsh/site-functions/`.

### Examples
<img width="805" height="92" alt="image" src="https://github.com/user-attachments/assets/306c47a6-f27f-4ad8-aef5-d6ee52a92917" />

<img width="560" height="131" alt="image" src="https://github.com/user-attachments/assets/1eac00bf-c281-41de-a0d7-decd7595e49c" />

